### PR TITLE
api: remove dependency on mikebeyer/env

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,10 +11,6 @@
 			"Rev": "f9982619ccace7df963bb7f6d1de3a6f014ff709"
 		},
 		{
-			"ImportPath": "github.com/mikebeyer/env",
-			"Rev": "b6ce30ccdcad3ed9d5ca80329829f5aeaa856e99"
-		},
-		{
 			"ImportPath": "github.com/stretchr/objx",
 			"Rev": "cbeaeb16a013161a98496fad62933b1d21786672"
 		},

--- a/api/api.go
+++ b/api/api.go
@@ -11,8 +11,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-
-	"github.com/mikebeyer/env"
 )
 
 var debug = os.Getenv("DEBUG") != ""
@@ -182,8 +180,14 @@ func EnvConfig() (Config, error) {
 // Defaults for Alias, BaseURL, and UserAgent will be taken from respective env vars.
 func NewConfig(username, password string) (Config, error) {
 	alias := os.Getenv("CLC_ALIAS")
-	agent := env.String("CLC_USER_AGENT", userAgentDefault)
-	base := env.String("CLC_BASE_URL", baseUriDefault)
+	agent := userAgentDefault
+	if v := os.Getenv("CLC_USER_AGENT"); v != "" {
+		agent = v
+	}
+	base := baseUriDefault
+	if v := os.Getenv("CLC_BASE_URL"); v != "" {
+		base = v
+	}
 	uri, err := url.Parse(base)
 	return Config{
 		User: User{


### PR DESCRIPTION
I noticed the additional mikebeyer/env coming in as I was working out
vendoring for Terraform. Since it's only used in these two lines, I
think it's a decent tradeoff to refactor to just use `os.Getenv` and
drop the extra dependency.