### PR TITLE
Networks

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -1,0 +1,87 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/CenturyLinkCloud/clc-sdk/api"
+	"github.com/CenturyLinkCloud/clc-sdk/status"
+)
+
+func New(client api.HTTP) *Service {
+	return &Service{
+		client: client,
+		config: client.Config(),
+	}
+}
+
+type Service struct {
+	client api.HTTP
+	config *api.Config
+}
+
+/*
+ * Networks are "claimed" and "released" from the datacenter.
+ * Claim returns a status.QueuedOperation object which should be polled until status=succeeded.
+ * At which point, an api.Link object with rel=network can be inspected for the ID of the claimed network.
+ */
+
+func (s *Service) List(dc string) (*[]Network, error) {
+	resp := &[]Network{}
+	url := fmt.Sprintf("%s/networks/%s/%s", s.config.BaseURL, s.config.Alias, dc)
+	err := s.client.Get(url, resp)
+	return resp, err
+}
+
+func (s *Service) Get(dc, id string) (*Network, error) {
+	url := fmt.Sprintf("%s/networks/%s/%s/%s", s.config.BaseURL, s.config.Alias, dc, id)
+	resp := &Network{}
+	err := s.client.Get(url, resp)
+	return resp, err
+}
+
+func (s *Service) GetAddresses(dc, id string) (*[]IP, error) {
+	resp := &[]IP{}
+	url := fmt.Sprintf("%s/networks/%s/%s/%s/ipAddresses", s.config.BaseURL, s.config.Alias, dc, id)
+	err := s.client.Get(url, resp)
+	return resp, err
+}
+
+func (s *Service) Claim(dc string) (*status.QueuedOperation, error) {
+	resp := &status.QueuedOperation{}
+	url := fmt.Sprintf("%s/networks/%s/%s/claim", s.config.BaseURL, s.config.Alias, dc)
+	err := s.client.Post(url, "", resp)
+	return resp, err
+}
+
+func (s *Service) Release(dc, id string) error {
+	url := fmt.Sprintf("%s/networks/%s/%s/%s/release", s.config.BaseURL, s.config.Alias, dc, id)
+	err := s.client.Post(url, "", nil)
+	return err
+}
+
+func (s *Service) Update(dc, id, name, description string) error {
+	url := fmt.Sprintf("%s/networks/%s/%s/%s", s.config.BaseURL, s.config.Alias, dc, id)
+	body := fmt.Sprintf(`{"name": "%s", "description": "%s"}`, name, description)
+	err := s.client.Post(url, body, nil)
+	return err
+}
+
+type Network struct {
+	ID          string    `json:"id"`
+	CIDR        string    `json:"cidr"`
+	Description string    `json:"description"`
+	Gateway     string    `json:"gateway"`
+	Name        string    `json:"name"`
+	Netmask     string    `json:"netmask"`
+	Type        string    `json:"type"`
+	VLAN        int       `json:"vlan"`
+	IPAddresses []IP      `json:"ipAddresses"`
+	Links       api.Links `json:"links"`
+}
+
+type IP struct {
+	Address string `json:"address"`
+	Claimed bool   `json:"claimed"`
+	Server  string `json:"server"`
+	Type    string `json:"type"` // private | virtual | publicMapped
+}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,0 +1,122 @@
+package network_test
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/CenturyLinkCloud/clc-sdk/api"
+	"github.com/CenturyLinkCloud/clc-sdk/network"
+	//"github.com/CenturyLinkCloud/clc-sdk/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const respClaim = `
+{
+  "requestType": "blueprintOperation",
+  "status": "succeeded",
+  "summary": {
+    "blueprintId": 92121,
+    "locationId": "DC",
+    "links": [
+       {
+         "rel": "network",
+         "href": "/v2-experimental/networks/ALIAS/DC/123456",
+         "id": "123456"
+       }
+    ]
+  }
+}
+`
+
+const respNetwork = `
+{
+    "id": "ec6ff75a0ffd4504840dab343fe41077",
+    "cidr": "11.22.33.0/24",
+    "description": "vlan_9999_11.22.33",
+    "gateway": "11.22.33.1",
+    "name": "vlan_9999_11.22.33",
+    "netmask": "255.255.255.0",
+    "type": "private",
+    "vlan": 9999,
+    "ipAddresses": [
+        {
+            "address": "11.22.33.12",
+            "claimed": true,
+            "server": "WA1ALIASAPI01",
+            "type": "private"
+        }
+    ],
+    "links": []
+}
+`
+
+func TestGetNetwork(t *testing.T) {
+	assert := assert.New(t)
+
+	client := NewMockClient()
+	client.On("Get", "http://localhost/v2-experimental/networks/ALIAS/DC/ec6ff75a0ffd4504840dab343fe41077", mock.Anything).Return(nil)
+	service := network.New(client)
+
+	id := "ec6ff75a0ffd4504840dab343fe41077"
+	resp, err := service.Get("DC", id)
+
+	assert.Nil(err)
+	assert.Equal(id, resp.ID)
+	assert.Equal("11.22.33.1", resp.Gateway)
+	assert.Equal("11.22.33.12", resp.IPAddresses[0].Address)
+	client.AssertExpectations(t)
+}
+
+func NewMockClient() *MockClient {
+	return &MockClient{}
+}
+
+type MockClient struct {
+	mock.Mock
+}
+
+func (m *MockClient) Get(url string, resp interface{}) error {
+	if strings.HasSuffix(url, "ec6ff75a0ffd4504840dab343fe41077") {
+		json.Unmarshal([]byte(respNetwork), resp)
+	}
+	args := m.Called(url, resp)
+	return args.Error(0)
+}
+
+func (m *MockClient) Post(url string, body, resp interface{}) error {
+	if strings.HasSuffix(url, "claim") {
+		json.Unmarshal([]byte(respClaim), resp)
+	}
+	if strings.HasSuffix(url, "release") {
+		// 204 on release
+	}
+	args := m.Called(url, resp)
+	return args.Error(0)
+}
+
+func (m *MockClient) Put(url string, body, resp interface{}) error {
+	return nil
+}
+
+func (m *MockClient) Patch(url string, body, resp interface{}) error {
+	return nil
+}
+
+func (m *MockClient) Delete(url string, resp interface{}) error {
+	return nil
+}
+
+func (m *MockClient) Config() *api.Config {
+	u, _ := url.Parse("http://localhost/v2-experimental")
+	return &api.Config{
+		User: api.User{
+			Username: "test.user",
+			Password: "s0s3cur3",
+		},
+		Alias:   "ALIAS",
+		BaseURL: u,
+	}
+}

--- a/status/status.go
+++ b/status/status.go
@@ -30,6 +30,13 @@ func (s *Service) Get(id string) (*Response, error) {
 	return status, err
 }
 
+func (s *Service) GetBlueprint(id string) (*BlueprintOperation, error) {
+	url := fmt.Sprintf("%s/operations/%s/status/%s", s.config.BaseURL, s.config.Alias, id)
+	status := &BlueprintOperation{}
+	err := s.client.Get(url, status)
+	return status, err
+}
+
 func (s *Service) Poll(id string, poll chan *Response) error {
 	for {
 		status, err := s.Get(id)
@@ -127,4 +134,36 @@ func (q *QueuedOperation) Status() *Status {
 		st.Href = href
 	}
 	return st
+}
+
+/* BlueprintOperation is a status object representing a running blueprint job
+    {
+      "requestType":"blueprintOperation",
+      "status":"succeeded",
+      "summary":{
+	"blueprintId":51229,
+	"locationId":"CA1",
+	"links":[
+	  {
+	    "rel":"network",
+	    "href":"/v2-experimental/networks/ZZBB/CA1/6955e7c39b5648df91bfb32e5d0aa24b",
+	    "id":"6955e7c39b5648df91bfb32e5d0aa24b"
+	  }
+	]
+      },
+      "source":{"userName":"ack","requestedAt":"2016-03-24T16:47:04Z"}
+    }
+*/
+type BlueprintOperation struct {
+	RequestType string `json:"requestType,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Summary     struct {
+		BlueprintID int       `json:"blueprintId,omitempty"`
+		LocationID  string    `json:"locationId,omitempty"`
+		Links       api.Links `json:"links,omitempty"`
+	} `json:"summary,omitempty"`
+	Source struct {
+		UserName    string    `json:"userName"`
+		RequestedAt time.Time `json:"requestedAt,omitempty"`
+	} `json:"source,omitempty"`
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +58,20 @@ func TestPollStatus_ErrorGettingStatus(t *testing.T) {
 	assert.NotNil(err)
 }
 
+func TestStatusBlueprintOperation(t *testing.T) {
+	assert := assert.New(t)
+
+	client := NewMockClient()
+	client.On("Get", "http://localhost/v2/operations/test/status/blueprint", mock.Anything).Return(nil)
+	service := status.New(client)
+
+	resp, err := service.GetBlueprint("blueprint")
+
+	assert.Nil(err)
+	assert.Equal("blueprintOperation", resp.RequestType)
+	assert.Equal("network", resp.Summary.Links[0].Rel)
+}
+
 func NewMockClient() *MockClient {
 	return &MockClient{}
 }
@@ -68,12 +83,16 @@ type MockClient struct {
 }
 
 func (m *MockClient) Get(url string, resp interface{}) error {
-	if m.count <= 1 {
-		json.Unmarshal([]byte(`{"status":"executing"}`), resp)
+	if strings.HasSuffix(url, "blueprint") {
+		json.Unmarshal([]byte(respBlueprintOperation), resp)
 	} else {
-		json.Unmarshal([]byte(`{"status":"succeeded"}`), resp)
+		if m.count <= 1 {
+			json.Unmarshal([]byte(`{"status":"executing"}`), resp)
+		} else {
+			json.Unmarshal([]byte(`{"status":"succeeded"}`), resp)
+		}
+		m.count++
 	}
-	m.count++
 	args := m.Called(url, resp)
 	return args.Error(0)
 }
@@ -109,3 +128,22 @@ func (m *MockClient) Config() *api.Config {
 		BaseURL: u,
 	}
 }
+
+var respBlueprintOperation = `
+{
+  "requestType":"blueprintOperation",
+  "status":"succeeded",
+  "summary":{
+    "blueprintId":51229,
+    "locationId":"CA1",
+    "links":[
+      {
+	"rel":"network",
+	"href":"/v2-experimental/networks/ZZBB/CA1/6955e7c39b5648df91bfb32e5d0aa24b",
+	"id":"6955e7c39b5648df91bfb32e5d0aa24b"
+      }
+    ]
+  },
+  "source":{"userName":"ack","requestedAt":"2016-03-24T16:47:04Z"}
+}
+`


### PR DESCRIPTION
Adds API calls + light tests around the networks entity. 

Duplicated `Status.Get` call for `Status.GetBlueprint`. I could converge the fields from BlueprintOperation into Status, but it's just another story for us to consider if/when we move to an interface. 

Have a gander at this branch and let me know if you have an opinion on any of it. 