### PR TITLE
Fix for issue #16

### DIFF
--- a/dc/dc.go
+++ b/dc/dc.go
@@ -52,7 +52,7 @@ type CapabilitiesResponse struct {
 	Templates                  []struct {
 		Name               string   `json:"name"`
 		Description        string   `json:"description"`
-		StorageSizeGB      string   `json:"storageSizeGB"`
+		StorageSizeGB      int      `json:"storageSizeGB"`
 		Capabilities       []string `json:"capabilities"`
 		ReservedDrivePaths []string `json:"reservedDrivePaths"`
 	} `json:"templates"`


### PR DESCRIPTION
This a fix for issue #16 to do with unmarshaling json into the CapabilitiesResponse struct.

The type for StorageSizeGB has been changed from string to int.